### PR TITLE
Fixes wrong event name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ new Vue({
 Emits events
 
 ```html
-<DraggableCal @selectedDate="doSomething($event)"></DraggableCal>
+<DraggableCal @dateSelected="doSomething($event)"></DraggableCal>
 ```
 
 ## Available props


### PR DESCRIPTION
The name of the emitted event when a date is selected is dateSelected not selectedDate